### PR TITLE
Dinner > 晩御飯の予定をFirestoreから取得する

### DIFF
--- a/src/features/dinner/api/read-dinnerPlans.ts
+++ b/src/features/dinner/api/read-dinnerPlans.ts
@@ -6,7 +6,7 @@ export const readDinnerPlans = async (
   groupId: string,
   date: string
 ) => {
-  let dinnerPlans: DinnerPlanType[] | null = null;
+  let dinnerPlans: DinnerPlanType[] = [];
   const dinnerPlansDocs = await getDocs(
     collection(
       db,
@@ -18,9 +18,10 @@ export const readDinnerPlans = async (
     )
   );
   console.log(dinnerPlansDocs.docs);
-  if (dinnerPlansDocs.empty) {
-    console.log("該当するデータがありません");
-  } else {
-    console.log(dinnerPlansDocs.docs.map((doc) => doc.data()));
+  if (!dinnerPlansDocs.empty) {
+    dinnerPlansDocs.forEach((doc) =>
+      dinnerPlans.push(doc.data() as DinnerPlanType)
+    );
   }
+  return dinnerPlans;
 };

--- a/src/features/dinner/components/DinnerPlans.tsx
+++ b/src/features/dinner/components/DinnerPlans.tsx
@@ -1,60 +1,22 @@
-import { Accordion, Text } from "@mantine/core";
-import { Firestore } from "firebase/firestore";
-import { useContext, useEffect, useState } from "react";
-import { FirebaseContext, UserContext } from "../../../contexts";
-import { readDinnerPlans } from "../api/read-dinnerPlans";
-import { DinnerPlanType } from "../types";
+import { Accordion, Center, Loader, Text } from "@mantine/core";
 import { DinnerPlan } from "./DinnerPlan";
 import dayjs from "dayjs";
-
-const DINNERPLANS: DinnerPlanType[] = [
-  {
-    status: "不要",
-    description: "外食します",
-    user: {
-      id: "11112341",
-      displayName: "aaaaaa",
-      avatarColor: "green.3",
-    },
-  },
-  {
-    status: "遅め",
-    description: "仕事で遅れます",
-    user: {
-      id: "111123423",
-      displayName: "abcde",
-      avatarColor: "blue.3",
-    },
-  },
-  {
-    status: "必要",
-    description: "",
-    user: {
-      id: "1112321",
-      displayName: "oooook",
-      avatarColor: "red.3",
-    },
-  },
-];
+import useReadDinnerPlans from "../hooks/useReadDinnerPlans";
 
 export const DinnerPlans = () => {
-  const [dinnerPlans, setDinnerPlans] = useState<DinnerPlanType[] | null>(null);
-  const { db } = useContext(FirebaseContext);
-  const { user } = useContext(UserContext);
+  const { dinnerPlans, isLoading } = useReadDinnerPlans();
   const date = new Date();
-  useEffect(() => {
-    setDinnerPlans(DINNERPLANS);
-    if (user && user.groupId) {
-      readDinnerPlans(db as Firestore, user.groupId, "2022-11-27");
-    }
-  }, []);
-
   return (
     <>
       <Text size="xl" mb="md" weight={700}>
         {dayjs(date).format("YYYY年MM月DD日")}の予定
       </Text>
-      {dinnerPlans ? (
+      {isLoading && (
+        <Center>
+          <Loader />
+        </Center>
+      )}
+      {!isLoading && dinnerPlans ? (
         <div>
           <Accordion
             styles={{

--- a/src/features/dinner/components/DinnerPlansWithCalendar.tsx
+++ b/src/features/dinner/components/DinnerPlansWithCalendar.tsx
@@ -1,45 +1,15 @@
-import {
-  Accordion,
-  ActionIcon,
-  Center,
-  Loader,
-  LoadingOverlay,
-  Text,
-} from "@mantine/core";
-import { Firestore } from "firebase/firestore";
-import { useContext, useEffect, useState } from "react";
-import { FirebaseContext, UserContext } from "../../../contexts";
-import { readDinnerPlans } from "../api/read-dinnerPlans";
-import { DinnerPlanType } from "../types";
+import { Accordion, ActionIcon, Center, Loader, Text } from "@mantine/core";
 import { DinnerPlan } from "./DinnerPlan";
 import "dayjs/locale/ja";
 import { Calendar } from "@mantine/dates";
 import dayjs from "dayjs";
 import { IconPlus } from "@tabler/icons";
 import { CreateDinnerPlanModal } from "./CreateDinnerPlanModal";
+import useReadDinnerPlans from "../hooks/useReadDinnerPlans";
 
 export const DinnerPlansWithCalendar = () => {
-  const [dinnerPlans, setDinnerPlans] = useState<DinnerPlanType[] | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [opened, setOpened] = useState(false);
-  const [date, setDate] = useState(new Date());
-  const { db } = useContext(FirebaseContext);
-  const { user } = useContext(UserContext);
-  useEffect(() => {
-    (async () => {
-      setIsLoading(true);
-      if (user && user.groupId) {
-        const data = await readDinnerPlans(
-          db as Firestore,
-          user.groupId,
-          dayjs(date).format("YYYY-MM-DD")
-        );
-        if (data?.length) setDinnerPlans(data);
-        else setDinnerPlans(null);
-      }
-      setIsLoading(false);
-    })();
-  }, [date]);
+  const { dinnerPlans, isLoading, opened, setOpened, date, setDate } =
+    useReadDinnerPlans();
 
   return (
     <>

--- a/src/features/dinner/hooks/useReadDinnerPlans.ts
+++ b/src/features/dinner/hooks/useReadDinnerPlans.ts
@@ -1,0 +1,44 @@
+import { Firestore } from "firebase/firestore";
+import { useContext, useEffect, useState } from "react";
+import { FirebaseContext, UserContext } from "../../../contexts";
+import { readDinnerPlans } from "../api/read-dinnerPlans";
+import { DinnerPlanType } from "../types";
+import "dayjs/locale/ja";
+import dayjs from "dayjs";
+import { showNotification } from "@mantine/notifications";
+
+const useReadDinnerPlans = () => {
+  const [dinnerPlans, setDinnerPlans] = useState<DinnerPlanType[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [opened, setOpened] = useState(false);
+  const [date, setDate] = useState(new Date());
+  const { db } = useContext(FirebaseContext);
+  const { user } = useContext(UserContext);
+  useEffect(() => {
+    (async () => {
+      setIsLoading(true);
+      if (user && user.groupId) {
+        try {
+          const data = await readDinnerPlans(
+            db as Firestore,
+            user.groupId,
+            dayjs(date).format("YYYY-MM-DD")
+          );
+          if (data?.length) setDinnerPlans(data);
+          else setDinnerPlans(null);
+        } catch (error) {
+          showNotification({
+            message: "予定の取得に失敗しました",
+            color: "red",
+          });
+          setDinnerPlans(null);
+        }
+      }
+      setIsLoading(false);
+    })();
+  }, [date]);
+
+  return { dinnerPlans, isLoading, opened, setOpened, date, setDate };
+};
+
+export default useReadDinnerPlans;


### PR DESCRIPTION
## なぜやるのか
- 現状はモックデータから予定を表示している
- Firestoreから予定を取得して表示させたい

## なにをしたのか
- `readDinnerPlans`関数の修正
- `useReadDinnerPlans`フックを作成
- `DinnerPlans`と`DinnerPlansWithCalendar`にフックを組み込み