### PR TITLE
Auth > ログイン画面の実装 

### DIFF
--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,0 +1,90 @@
+import {
+  TextInput,
+  Paper,
+  Container,
+  Title,
+  PasswordInput,
+  Button,
+  Divider,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { showNotification } from "@mantine/notifications";
+import { Auth, signInWithEmailAndPassword } from "firebase/auth";
+import { useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import { FirebaseContext } from "../../../contexts";
+
+const LoginForm = () => {
+  const navigate = useNavigate();
+  const { auth } = useContext(FirebaseContext);
+
+  const form = useForm({
+    initialValues: {
+      email: "",
+      password: "",
+    },
+    validate: {
+      email: (value) =>
+        /^\S+@\S+$/.test(value)
+          ? null
+          : "正しいメールアドレスを入力してください",
+      password: (value) =>
+        value.length < 1 ? "パスワードを入力してください" : null,
+    },
+  });
+
+  return (
+    <Container size={400} my={40}>
+      <Title align="center" color="cyan.9">
+        ログイン
+      </Title>
+      <Paper p="xl" mx="auto" my="lg" withBorder>
+        <form
+          onSubmit={form.onSubmit(async (values) => {
+            try {
+              await signInWithEmailAndPassword(
+                auth as Auth,
+                values.email,
+                values.password
+              );
+              navigate("/app");
+            } catch (error) {
+              showNotification({
+                message: "メールアドレスまたはパスワードが正しくありません",
+                color: "red",
+              });
+            }
+          })}
+        >
+          <TextInput
+            withAsterisk
+            label="メールアドレス"
+            placeholder="xxx@example.com"
+            {...form.getInputProps("email")}
+          />
+          <PasswordInput
+            withAsterisk
+            label="パスワード"
+            placeholder="●●●●●●"
+            mt="md"
+            {...form.getInputProps("password")}
+          />
+          <Button type="submit" color="cyan" mt="xl" fullWidth>
+            ログイン
+          </Button>
+          <Divider my="sm" label="または" labelPosition="center" />
+          <Button
+            variant="subtle"
+            color="cyan"
+            fullWidth
+            onClick={() => navigate("/auth/register")}
+          >
+            新規登録
+          </Button>
+        </form>
+      </Paper>
+    </Container>
+  );
+};
+
+export default LoginForm;

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -7,31 +7,10 @@ import {
   Button,
   Divider,
 } from "@mantine/core";
-import { useForm } from "@mantine/form";
-import { showNotification } from "@mantine/notifications";
-import { Auth, signInWithEmailAndPassword } from "firebase/auth";
-import { useContext } from "react";
-import { useNavigate } from "react-router-dom";
-import { FirebaseContext } from "../../../contexts";
+import useLogin from "../hooks/useLogin";
 
 const LoginForm = () => {
-  const navigate = useNavigate();
-  const { auth } = useContext(FirebaseContext);
-
-  const form = useForm({
-    initialValues: {
-      email: "",
-      password: "",
-    },
-    validate: {
-      email: (value) =>
-        /^\S+@\S+$/.test(value)
-          ? null
-          : "正しいメールアドレスを入力してください",
-      password: (value) =>
-        value.length < 1 ? "パスワードを入力してください" : null,
-    },
-  });
+  const { form, handleLogin, navigateToRegister } = useLogin();
 
   return (
     <Container size={400} my={40}>
@@ -39,23 +18,7 @@ const LoginForm = () => {
         ログイン
       </Title>
       <Paper p="xl" mx="auto" my="lg" withBorder>
-        <form
-          onSubmit={form.onSubmit(async (values) => {
-            try {
-              await signInWithEmailAndPassword(
-                auth as Auth,
-                values.email,
-                values.password
-              );
-              navigate("/app");
-            } catch (error) {
-              showNotification({
-                message: "メールアドレスまたはパスワードが正しくありません",
-                color: "red",
-              });
-            }
-          })}
-        >
+        <form onSubmit={handleLogin}>
           <TextInput
             withAsterisk
             label="メールアドレス"
@@ -77,7 +40,7 @@ const LoginForm = () => {
             variant="subtle"
             color="cyan"
             fullWidth
-            onClick={() => navigate("/auth/register")}
+            onClick={navigateToRegister}
           >
             新規登録
           </Button>

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -5,6 +5,7 @@ import {
   Title,
   PasswordInput,
   Button,
+  Divider,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { Auth, createUserWithEmailAndPassword } from "firebase/auth";
@@ -72,6 +73,15 @@ const RegisterForm = () => {
           />
           <Button type="submit" color="cyan.6" mt="xl" fullWidth>
             新規登録
+          </Button>
+          <Divider my="sm" label="または" labelPosition="center" />
+          <Button
+            variant="subtle"
+            color="cyan"
+            fullWidth
+            onClick={() => navigate("/auth/login")}
+          >
+            ログイン
           </Button>
         </form>
       </Paper>

--- a/src/features/auth/hooks/useLogin.ts
+++ b/src/features/auth/hooks/useLogin.ts
@@ -1,0 +1,48 @@
+import { useForm } from "@mantine/form";
+import { showNotification } from "@mantine/notifications";
+import { Auth, signInWithEmailAndPassword } from "firebase/auth";
+import { useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import { FirebaseContext } from "../../../contexts";
+
+const useLogin = () => {
+  const navigate = useNavigate();
+  const { auth } = useContext(FirebaseContext);
+
+  const form = useForm({
+    initialValues: {
+      email: "",
+      password: "",
+    },
+    validate: {
+      email: (value) =>
+        /^\S+@\S+$/.test(value)
+          ? null
+          : "正しいメールアドレスを入力してください",
+      password: (value) =>
+        value.length < 1 ? "パスワードを入力してください" : null,
+    },
+  });
+
+  const handleLogin = form.onSubmit(async (values) => {
+    try {
+      await signInWithEmailAndPassword(
+        auth as Auth,
+        values.email,
+        values.password
+      );
+      navigate("/app");
+    } catch (error) {
+      showNotification({
+        message: "メールアドレスまたはパスワードが正しくありません",
+        color: "red",
+      });
+    }
+  });
+
+  const navigateToRegister = () => navigate("/auth/register");
+
+  return { form, handleLogin, navigateToRegister };
+};
+
+export default useLogin;

--- a/src/features/auth/routes/AuthRoutes.tsx
+++ b/src/features/auth/routes/AuthRoutes.tsx
@@ -1,10 +1,13 @@
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
+import LoginForm from "../components/LoginForm";
 import RegisterForm from "../components/RegisterForm";
 
 export const AuthRoutes = () => {
   return (
     <Routes>
       <Route path="register" element={<RegisterForm />} />
+      <Route path="login" element={<LoginForm />} />
+      <Route path="*" element={<Navigate to="/auth/login" />} />
     </Routes>
   );
 };

--- a/src/routes/public.tsx
+++ b/src/routes/public.tsx
@@ -8,6 +8,6 @@ export const publicRoutes = [
   },
   {
     path: "*",
-    element: <Navigate to="/auth/register" />,
+    element: <Navigate to="/auth/login" />,
   },
 ];


### PR DESCRIPTION
## issue
- #8 

## なぜやるのか
- 現状では、新規登録からしか認証が出来ない状態になっている
- ログインができるようにしたい

## なにをやったのか
- `LoginForm`コンポーネントの作成
- `useLogin`フックの作成・組み込み
- 新規登録画面からログイン画面への遷移を追加

## スクリーンショット
![cdd47da1ee44820af053bb4449bcf7a2](https://user-images.githubusercontent.com/106266114/209458697-92bf1793-4e04-47e8-96ad-b6a00e152f66.png)
